### PR TITLE
fix: evaluate.py - folder path bug

### DIFF
--- a/src/gwit/evaluation/evaluate.py
+++ b/src/gwit/evaluation/evaluate.py
@@ -220,7 +220,7 @@ if __name__ == '__main__':
             # print(gt_folder + gt_name)
 
             # Load GT image and the path of genetrated images
-            real_image = Image.open(gt_folder + gt_images_name[j]).convert('RGB')
+            real_image = Image.open(gt_folder + '/' + gt_images_name[j]).convert('RGB')
 
             # gene_image_name=[]
             # name1 = gt_name.split('_')[0] + '_' + gt_name.split('_')[1] + '_' + gt_name.split('_')[2] + '_' + \
@@ -244,7 +244,7 @@ if __name__ == '__main__':
             # Evaluate
             for i in range(0,args.limit):
                 # print(gene_folder + gn_imges_name[i])
-                generated_image = Image.open(gene_folder + gn_imges_name[j+i]).convert('RGB')
+                generated_image = Image.open(gene_folder + '/' + gn_imges_name[j+i]).convert('RGB')
                 pred = preprocess(generated_image).unsqueeze(0).to("cuda")
                 pred_out = model(pred).squeeze(0).softmax(0).detach()
                 acc, std = n_way_top_k_acc(pred_out, gt_class_id, n_way, num_trials, top_k)

--- a/src/gwit/evaluation/evaluate.py
+++ b/src/gwit/evaluation/evaluate.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
 
     acc_list = []
     gt_folder = os.path.join(args.controlnet_path,'guess','ground_truth') if args.guess else os.path.join(args.controlnet_path,'ground_truth')
-    gene_folder= os.path.join(args.controlnet_path,'guess','generated')   if args.guess else os.path.join(args.controlnet_path,'ground_truth') 
+    gene_folder= os.path.join(args.controlnet_path,'guess','generated')   if args.guess else os.path.join(args.controlnet_path,'generated') 
     
     gt_images_name = os.listdir(gt_folder)
     gt_images_name.sort()

--- a/src/gwit/train_controlnet.py
+++ b/src/gwit/train_controlnet.py
@@ -760,11 +760,11 @@ def make_train_dataset(args, tokenizer, accelerator):
     else:
         from dataset_EEG.name_map_ID import id_to_caption_TVIZ as id_to_caption
         print(id_to_caption)
-    model     = EEGFeatNet(n_features=128, projection_dim=128, num_layers=4).to("cuda") if "CVPR" in args.dataset_name else  \
+    model     = EEGFeatNet(n_features=128, projection_dim=128, num_layers=4).to("cuda:0") if "CVPR" in args.dataset_name else  \
                 EEGFeatNet(n_classes=10, in_channels=14,\
                            n_features=128, projection_dim=128,\
-                           num_layers=4).to("cuda")
-    model     = torch.nn.DataParallel(model).to("cuda")
+                           num_layers=4).to("cuda:0")
+    model     = torch.nn.DataParallel(model).to("cuda:0")
     import pickle
 
     # Load the model from the file


### PR DESCRIPTION
The incorrect gene_folder setting (ground_truth -> generated) 
might have caused the negative FID issue, 
as seen in #3.